### PR TITLE
fix/강아지 정보수정 오류수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,4 @@ out/
 .vscode/
 
 ### Secret properties file (AWS 키 포함된 파일) ###
-src/main/resources/application-secrets.properties
+src/main/resources/application-secret.properties

--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,4 @@ out/
 .vscode/
 
 ### Secret properties file (AWS 키 포함된 파일) ###
-src/main/resources/application-secret.properties
+src/main/resources/application-secrets.properties

--- a/src/main/java/com/example/dogmeeting/controller/DogController.java
+++ b/src/main/java/com/example/dogmeeting/controller/DogController.java
@@ -86,8 +86,10 @@ public class DogController {
     @PutMapping("/{dogId}")
     public ResponseEntity<String> updateDog(
             @PathVariable Long dogId,
-            @Valid @RequestBody DogCreateRequest request) {
-        dogService.updateDog(dogId, request);
+            @Valid @RequestPart("dogInfo") DogCreateRequest request,
+            @RequestPart(value = "image", required = false) MultipartFile image) {
+
+        dogService.updateDog(dogId, request, image); // 이미지 처리 로직은 서비스에서 담당
         return ResponseEntity.ok("강아지 정보가 성공적으로 업데이트되었습니다.");
     }
 

--- a/src/main/java/com/example/dogmeeting/entity/Dog.java
+++ b/src/main/java/com/example/dogmeeting/entity/Dog.java
@@ -40,12 +40,11 @@ public class Dog {
     @OneToMany(mappedBy = "dog", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<DogTitle> dogTitles;
 
-    public void updateInfo(String name, String breed, Integer age, String description, String photoUrl) {
+    public void updateInfo(String name, String breed, Integer age, String description) {
         this.name = name;
         this.breed = breed;
         this.age = age;
         this.description = description;
-        this.photoUrl = photoUrl;
     }
 
     public void updatePhotoUrl(String photoUrl) {

--- a/src/main/java/com/example/dogmeeting/service/DogService.java
+++ b/src/main/java/com/example/dogmeeting/service/DogService.java
@@ -12,7 +12,7 @@ public interface DogService {
     DogResponse getDogById(Long dogId);
     DogProfileResponse getDogProfile(Long dogId);
     List<DogResponse> getDogsByUserId(Long userId);
-    void updateDog(Long dogId, DogCreateRequest request);
+    void updateDog(Long dogId, DogCreateRequest request, org.springframework.web.multipart.MultipartFile image);
     void updateDogImage(Long dogId, String imageUrl);
     void deleteDog(Long dogId);
     

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,8 +1,6 @@
 server.port=8080
 spring.application.name=dogmeeting
-spring.datasource.url=jdbc:mysql://localhost:3306/dogmeeting?useSSL=false&serverTimezone=UTC&allowPublicKeyRetrieval=true
-spring.datasource.username=root
-spring.datasource.password=0000
+spring.datasource.url=jdbc:mysql://dogmeeting.cfu60k8ccem4.ap-northeast-2.rds.amazonaws.com:3306/dogmeeting?useSSL=false&serverTimezone=UTC&allowPublicKeyRetrieval=true 
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,10 +1,11 @@
 server.port=8080
 spring.application.name=dogmeeting
-spring.datasource.url=jdbc:mysql://localhost:3306/dogmeeting?useSSL=false&serverTimezone=UTC&allowPublicKeyRetrieval=true
-spring.datasource.username=root
-spring.datasource.password=0000
+spring.datasource.url=jdbc:mysql://dogmeeting.cfu60k8ccem4.ap-northeast-2.rds.amazonaws.com:3306/dogmeeting?useSSL=false&serverTimezone=UTC&allowPublicKeyRetrieval=true
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.jpa.hibernate.ddl-auto=update
+spring.datasource.username=admin
+spring.datasource.password=skadbstjd12
 spring.jpa.show-sql=true
+spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect
 logging.level.root=DEBUG
 logging.level.com.example.dogmeeting=DEBUG

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,11 +1,10 @@
 server.port=8080
 spring.application.name=dogmeeting
-spring.datasource.url=jdbc:mysql://dogmeeting.cfu60k8ccem4.ap-northeast-2.rds.amazonaws.com:3306/dogmeeting?useSSL=false&serverTimezone=UTC&allowPublicKeyRetrieval=true
+spring.datasource.url=jdbc:mysql://localhost:3306/dogmeeting?useSSL=false&serverTimezone=UTC&allowPublicKeyRetrieval=true
+spring.datasource.username=root
+spring.datasource.password=0000
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.jpa.hibernate.ddl-auto=update
-spring.datasource.username=admin
-spring.datasource.password=skadbstjd12
 spring.jpa.show-sql=true
-spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect
 logging.level.root=DEBUG
 logging.level.com.example.dogmeeting=DEBUG

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,3 +6,5 @@ spring.datasource.password=0000
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
+logging.level.root=DEBUG
+logging.level.com.example.dogmeeting=DEBUG


### PR DESCRIPTION
강아지 정보 수정 시 이미지를 함께 보내도 이미지 URL이 null로 저장되는 오류가 발생하여, 정보 수정에서 새로운 이미지가 요청으로 들어왔을 때, 기본 정보에 있던 이미지를 삭제하고 새로운 이미지를 s3에 저장한 후 그 url을 반환하는 방식으로 수정함.